### PR TITLE
Unit Tests

### DIFF
--- a/Veritrans/ApiRequestor.php
+++ b/Veritrans/ApiRequestor.php
@@ -50,6 +50,19 @@ class Veritrans_ApiRequestor {
       CURLOPT_CAINFO => dirname(__FILE__) . "/../data/cacert.pem"
     );
 
+    // merging with Veritrans_Config::$curlOptions
+    if (count(Veritrans_Config::$curlOptions)) {
+      // We need to combine headers manually, because it's array and it will no be merged
+      if (Veritrans_Config::$curlOptions[CURLOPT_HTTPHEADER]) {
+        $mergedHeders = array_merge($curl_options[CURLOPT_HTTPHEADER], Veritrans_Config::$curlOptions[CURLOPT_HTTPHEADER]);
+        $headerOptions = array( CURLOPT_HTTPHEADER => $mergedHeders );
+      } else {
+        $mergedHeders = array();
+      }
+
+      $curl_options = array_replace_recursive($curl_options, Veritrans_Config::$curlOptions, $headerOptions);
+    }
+
     if ($post) {
       $curl_options[CURLOPT_POST] = 1;
 

--- a/Veritrans/ApiRequestor.php
+++ b/Veritrans/ApiRequestor.php
@@ -1,17 +1,40 @@
 <?php
+/**
+ * Send reuquest to Veritrans API
+ * Better don't use this class directly, use Veritrans_VtWeb, Veritrans_VtDirect, Veritrans_Transaction
+ */
 
 class Veritrans_ApiRequestor {
 
+  /**
+   * Send GET request
+   * @param string  $url
+   * @param string  $server_key
+   * @param mixed[] $data_hash
+   */
   public static function get($url, $server_key, $data_hash)
   {
     return self::remoteCall($url, $server_key, $data_hash, false);
   }
 
+  /**
+   * Send POST request
+   * @param string  $url
+   * @param string  $server_key
+   * @param mixed[] $data_hash
+   */
   public static function post($url, $server_key, $data_hash)
   {
     return self::remoteCall($url, $server_key, $data_hash, true);
   }
 
+  /**
+   * Actually send request to API server
+   * @param string  $url
+   * @param string  $server_key
+   * @param mixed[] $data_hash
+   * @param bool    $post
+   */
   public static function remoteCall($url, $server_key, $data_hash, $post = true)
   {
     $ch = curl_init();

--- a/Veritrans/Config.php
+++ b/Veritrans/Config.php
@@ -1,17 +1,47 @@
 <?php
-
+/**
+ * Veritrans Configuration
+ */
 class Veritrans_Config {
 
+  /**
+   * Your merchant's server key
+   * @static
+   */
   public static $serverKey;
+  /**
+   * Your merchant's client key
+   * @static
+   */
   public static $client_key;
+  /**
+   * This should be 2
+   * @static
+   */
   public static $apiVersion = 2;
+  /**
+   * Make it true to integrate with production
+   * @static
+   */
   public static $isProduction = false;
+  /**
+   * Enable 3D Secure by default
+   * @static
+   */
   public static $is3ds = false;
+  /**
+   * Enable request params sanitizer (validate and modify charge request params).
+   * See Veritrans_Sanitizer for more details
+   * @static
+   */
   public static $isSanitized = false;
 
   const SANDBOX_BASE_URL = 'https://api.sandbox.veritrans.co.id/v2';
   const PRODUCTION_BASE_URL = 'https://api.veritrans.co.id/v2';
 
+  /**
+   * @return string Veritrans API URL, depends on $isProduction
+   */
   public static function getBaseUrl()
   {
     return Veritrans_Config::$isProduction ?

--- a/Veritrans/Config.php
+++ b/Veritrans/Config.php
@@ -13,7 +13,7 @@ class Veritrans_Config {
    * Your merchant's client key
    * @static
    */
-  public static $client_key;
+  public static $clientKey;
   /**
    * This should be 2
    * @static

--- a/Veritrans/Config.php
+++ b/Veritrans/Config.php
@@ -35,6 +35,11 @@ class Veritrans_Config {
    * @static
    */
   public static $isSanitized = false;
+  /**
+   * Default options for every request
+   * @static
+   */
+  public static $curlOptions = array();
 
   const SANDBOX_BASE_URL = 'https://api.sandbox.veritrans.co.id/v2';
   const PRODUCTION_BASE_URL = 'https://api.veritrans.co.id/v2';

--- a/Veritrans/Notification.php
+++ b/Veritrans/Notification.php
@@ -1,5 +1,15 @@
 <?php
-
+/**
+ * Read raw post input and parse as JSON. Provide getters for fields in notification object
+ *
+ * Example:
+ *
+ * ```php
+ *   $notif = new Veritrans_Notification();
+ *   echo $notif->order_id;
+ *   echo $notif->transaction_status;
+ * ```
+ */
 class Veritrans_Notification {
 
   private $response;

--- a/Veritrans/Sanitizer.php
+++ b/Veritrans/Sanitizer.php
@@ -1,5 +1,11 @@
 <?php
-
+/**
+ * Request params filters.
+ *
+ * It truncate fields that have length limit, remove not allowed characters from other fields
+ *
+ * This feature is optional, you can control it with Veritrans_Config::$isSanitized (default: false)
+ */
 class Veritrans_Sanitizer {
   private $filters;
 
@@ -8,6 +14,10 @@ class Veritrans_Sanitizer {
     $this->filters = array();
   }
 
+  /**
+   * Validates and modify data
+   * @param mixedp[] $json
+   */
   public static function jsonRequest(&$json)
   {
     $keys = array('item_details', 'customer_details');

--- a/Veritrans/Transaction.php
+++ b/Veritrans/Transaction.php
@@ -1,7 +1,14 @@
 <?php
-
+/**
+ * API methods to get transaction status, approvea and cancel transactions
+ */
 class Veritrans_Transaction {
 
+  /**
+   * Retrieve transaction status
+   * @param string $id Order ID or transaction ID
+   * @return mixed[]
+   */
   public static function status($id)
   {
     return Veritrans_ApiRequestor::get(
@@ -10,6 +17,11 @@ class Veritrans_Transaction {
         false);
   }
 
+  /**
+   * Appove challenge transaction
+   * @param string $id Order ID or transaction ID
+   * @return mixed[]
+   */
   public static function approve($id)
   {
     return Veritrans_ApiRequestor::post(
@@ -18,6 +30,11 @@ class Veritrans_Transaction {
         false)->status_code;
   }
 
+  /**
+   * Cancel transaction before it's setteled
+   * @param string $id Order ID or transaction ID
+   * @return mixed[]
+   */
   public static function cancel($id)
   {
     return Veritrans_ApiRequestor::post(

--- a/Veritrans/Transaction.php
+++ b/Veritrans/Transaction.php
@@ -20,7 +20,7 @@ class Veritrans_Transaction {
   /**
    * Appove challenge transaction
    * @param string $id Order ID or transaction ID
-   * @return mixed[]
+   * @return string
    */
   public static function approve($id)
   {
@@ -33,7 +33,7 @@ class Veritrans_Transaction {
   /**
    * Cancel transaction before it's setteled
    * @param string $id Order ID or transaction ID
-   * @return mixed[]
+   * @return string
    */
   public static function cancel($id)
   {

--- a/Veritrans/VtDirect.php
+++ b/Veritrans/VtDirect.php
@@ -1,12 +1,19 @@
 <?php
-
+/**
+ * Provide charge and capture functions for VT-Direct
+ */
 class Veritrans_VtDirect {
 
+  /**
+   * Create VT-Direct transaction.
+   *
+   * @param mixed[] $params Transaction options
+   */
   public static function charge($params)
   {
     $payloads = array(
         'payment_type' => 'credit_card'
-      );
+    );
 
     if (array_key_exists('item_details', $params)) {
       $gross_amount = 0;
@@ -29,17 +36,22 @@ class Veritrans_VtDirect {
 
     return $result;
   }
-  
+
+  /**
+   * Capture pre-authorized transaction
+   *
+   * @param string $param Order ID or transaction ID, that you want to capture
+   */
   public static function capture($param)
   {
-	$payloads = array(
-		'transaction_id' => $param,
-	);	
-	
-	$result = Veritrans_ApiRequestor::post(
-        Veritrans_Config::getBaseUrl() . '/capture',
-        Veritrans_Config::$serverKey,
-        $payloads);
+    $payloads = array(
+      'transaction_id' => $param,
+    );
+
+    $result = Veritrans_ApiRequestor::post(
+          Veritrans_Config::getBaseUrl() . '/capture',
+          Veritrans_Config::$serverKey,
+          $payloads);
 
     return $result;
   }

--- a/Veritrans/VtWeb.php
+++ b/Veritrans/VtWeb.php
@@ -1,16 +1,39 @@
 <?php
-
+/**
+ * Create VtWeb transaction and return redirect url
+ *
+ */
 class Veritrans_VtWeb {
 
+  /**
+   * Create VT-Web transaction
+   *
+   * Example:
+   *
+   * ```php
+   *   $params = array(
+   *     'transaction_details' => array(
+   *       'order_id' => rand(),
+   *       'gross_amount' => 10000,
+   *     )
+   *   );
+   *   $paymentUrl = Veritrans_Vtweb::getRedirectionUrl($params)
+   *   header('Location: ' . $paymentUrl);
+   * ```
+   *
+   * @param array $params Payment options
+   * @return string Redirect URL to VT-Web payment page.
+   * @throws Exception curl error or veritrans error
+   */
   public static function getRedirectionUrl($params)
   {
     $payloads = array(
-        'payment_type' => 'vtweb',
-        'vtweb' => array(
-          // 'enabled_payments' => array('credit_card'),
-          'credit_card_3d_secure' => Veritrans_Config::$is3ds
-        )
-      );
+      'payment_type' => 'vtweb',
+      'vtweb' => array(
+        // 'enabled_payments' => array('credit_card'),
+        'credit_card_3d_secure' => Veritrans_Config::$is3ds
+      )
+    );
 
     if (array_key_exists('item_details', $params)) {
       $gross_amount = 0;

--- a/Veritrans/VtWeb.php
+++ b/Veritrans/VtWeb.php
@@ -17,7 +17,7 @@ class Veritrans_VtWeb {
    *       'gross_amount' => 10000,
    *     )
    *   );
-   *   $paymentUrl = Veritrans_Vtweb::getRedirectionUrl($params)
+   *   $paymentUrl = Veritrans_Vtweb::getRedirectionUrl($params);
    *   header('Location: ' . $paymentUrl);
    * ```
    *

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.0.*"
+        "phpunit/phpunit": "4.5.*"
     },
     "autoload": {
         "classmap": [""]

--- a/tests/VeritransApiRequestorTest.php
+++ b/tests/VeritransApiRequestorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+require_once(dirname(__FILE__) . '/VtTests.php');
+require_once(dirname(__FILE__) . '/../Veritrans.php');
+
+class VeritransApiRequestorTest extends PHPUnit_Framework_TestCase
+{
+
+    public function testConfigOptionsOverrideCurlOptions() {
+      VT_Tests::$stubHttp = true;
+      VT_Tests::$stubHttpResponse = '{ "status_code": "200" }';
+
+      Veritrans_Config::$curlOptions = array(
+        CURLOPT_HTTPHEADER => array( "User-Agent: testing lib" ),
+        CURLOPT_PROXY => "http://proxy.com"
+      );
+
+      $resp = Veritrans_ApiRequestor::post("http://example.com", "", "");
+
+      $fields = VT_Tests::lastReqOptions();
+      $this->assertTrue(in_array("User-Agent: testing lib", $fields["HTTPHEADER"]));
+      $this->assertTrue(in_array('Content-Type: application/json', $fields["HTTPHEADER"]));
+
+      $this->assertEquals($fields["PROXY"], "http://proxy.com");
+    }
+
+    public function tearDown() {
+      VT_Tests::reset();
+      Veritrans_Config::$curlOptions = array();
+    }
+
+}

--- a/tests/VeritransConfigTest.php
+++ b/tests/VeritransConfigTest.php
@@ -17,4 +17,7 @@ class VeritransConfigTest extends PHPUnit_Framework_TestCase
             Veritrans_Config::PRODUCTION_BASE_URL);
     }
 
+    public function tearDown() {
+      Veritrans_Config::$isProduction = false;
+    }
 }

--- a/tests/VeritransConfigTest.php
+++ b/tests/VeritransConfigTest.php
@@ -1,0 +1,20 @@
+<?php
+
+require_once(dirname(__FILE__) . '/../Veritrans.php');
+
+class VeritransConfigTest extends PHPUnit_Framework_TestCase
+{
+
+    public function testReturnBaseUrl() {
+        Veritrans_Config::$isProduction = false;
+        $this->assertEquals(
+            Veritrans_Config::getBaseUrl(),
+            Veritrans_Config::SANDBOX_BASE_URL);
+
+        Veritrans_Config::$isProduction = true;
+        $this->assertEquals(
+            Veritrans_Config::getBaseUrl(),
+            Veritrans_Config::PRODUCTION_BASE_URL);
+    }
+
+}

--- a/tests/VeritransTransactionTest.php
+++ b/tests/VeritransTransactionTest.php
@@ -1,0 +1,146 @@
+<?php
+
+require_once(dirname(__FILE__) . '/VtTests.php');
+require_once(dirname(__FILE__) . '/../Veritrans.php');
+
+class VeritransTransactionTest extends PHPUnit_Framework_TestCase
+{
+
+    public function testStatus() {
+      Veritrans_Config::$serverKey = 'My Very Secret Key';
+      VT_Tests::$stubHttp = true;
+      VT_Tests::$stubHttpResponse = '{
+        "status_code": "200",
+        "status_message": "Success, transaction found",
+        "transaction_id": "e3b8c383-55b4-4223-bd77-15c48c0245ca",
+        "masked_card": "481111-1114",
+        "order_id": "Order-111",
+        "payment_type": "credit_card",
+        "transaction_time": "2014-11-21 13:07:50",
+        "transaction_status": "settlement",
+        "fraud_status": "accept",
+        "approval_code": "1416550071152",
+        "signature_key": "4ef8218aad5b64bae2ec9d6b0f0a0b059b88bd...",
+        "bank": "mandiri",
+        "gross_amount": "10000.00"
+      }';
+
+      $status = Veritrans_Transaction::status("Order-111");
+
+      $this->assertEquals($status->status_code, "200");
+      $this->assertEquals($status->order_id, "Order-111");
+      $this->assertEquals($status->approval_code, "1416550071152");
+
+      $this->assertEquals(
+        VT_Tests::$lastHttpRequest["url"],
+        "https://api.veritrans.co.id/v2/Order-111/status"
+      );
+
+      $fields = VT_Tests::lastReqOptions();
+      $this->assertFalse(array_key_exists("POST", $fields));
+      $this->assertFalse(array_key_exists("POSTFIELDS", $fields));
+
+      VT_Tests::reset();
+    }
+
+    public function testFailureStatus() {
+      Veritrans_Config::$serverKey = 'My Very Secret Key';
+      VT_Tests::$stubHttp = true;
+      VT_Tests::$stubHttpResponse = '{
+        "status_code": "404",
+        "status_message": "The requested resource is not found"
+      }';
+
+      try {
+        $status = Veritrans_Transaction::status("Order-111");
+      } catch (Exception $error) {
+        $errorHappen = true;
+        $this->assertEquals(
+          $error->getMessage(),
+          "Veritrans Error (404): The requested resource is not found");
+      }
+
+      $this->assertTrue($errorHappen);
+      VT_Tests::reset();
+    }
+
+    public function testRealStatus() {
+      try {
+        $status = Veritrans_Transaction::status("Order-111");
+      } catch (Exception $error) {
+        $errorHappen = true;
+        $this->assertEquals(
+          $error->getMessage(),
+          "Veritrans Error (401): Access denied due to unauthorized transaction, please check client or server key");
+      }
+
+      $this->assertTrue($errorHappen);
+    }
+
+    public function testApprove () {
+      VT_Tests::$stubHttp = true;
+      VT_Tests::$stubHttpResponse = '{
+        "status_code": "200",
+        "status_message": "Success, transaction is approved",
+        "transaction_id": "2af158d4-b82e-46ac-808b-be19aaa96ce3",
+        "masked_card": "451111-1117",
+        "order_id": "Order-111",
+        "payment_type": "credit_card",
+        "transaction_time": "2014-11-27 10:05:10",
+        "transaction_status": "capture",
+        "fraud_status": "accept",
+        "approval_code": "1416550071152",
+        "bank": "bni",
+        "gross_amount": "10000.00"
+      }';
+
+      $approve = Veritrans_Transaction::approve("Order-111");
+
+      $this->assertEquals($approve, "200");
+
+      $this->assertEquals(
+        VT_Tests::$lastHttpRequest["url"],
+        "https://api.veritrans.co.id/v2/Order-111/approve"
+      );
+
+      $fields = VT_Tests::lastReqOptions();
+      $this->assertEquals($fields["POST"], 1);
+      $this->assertEquals($fields["POSTFIELDS"], null);
+
+      VT_Tests::reset();
+    }
+
+    public function testCancel() {
+      VT_Tests::$stubHttp = true;
+      VT_Tests::$stubHttpResponse = '{
+        "status_code": "200",
+        "status_message": "Success, transaction is canceled",
+        "transaction_id": "2af158d4-b82e-46ac-808b-be19aaa96ce3",
+        "masked_card": "451111-1117",
+        "order_id": "Order-111",
+        "payment_type": "credit_card",
+        "transaction_time": "2014-11-27 10:05:10",
+        "transaction_status": "cancel",
+        "fraud_status": "accept",
+        "approval_code": "1416550071152",
+        "bank": "bni",
+        "gross_amount": "10000.00"
+      }';
+
+      $cancel = Veritrans_Transaction::cancel("Order-111");
+
+      $this->assertEquals($cancel, "200");
+
+      $this->assertEquals(
+        VT_Tests::$lastHttpRequest["url"],
+        "https://api.veritrans.co.id/v2/Order-111/cancel"
+      );
+
+      $fields = VT_Tests::lastReqOptions();
+      $this->assertEquals($fields["POST"], 1);
+      $this->assertEquals($fields["POSTFIELDS"], null);
+
+      VT_Tests::reset();
+    }
+
+}

--- a/tests/VeritransTransactionTest.php
+++ b/tests/VeritransTransactionTest.php
@@ -33,14 +33,12 @@ class VeritransTransactionTest extends PHPUnit_Framework_TestCase
 
       $this->assertEquals(
         VT_Tests::$lastHttpRequest["url"],
-        "https://api.veritrans.co.id/v2/Order-111/status"
+        "https://api.sandbox.veritrans.co.id/v2/Order-111/status"
       );
 
       $fields = VT_Tests::lastReqOptions();
       $this->assertFalse(array_key_exists("POST", $fields));
       $this->assertFalse(array_key_exists("POSTFIELDS", $fields));
-
-      VT_Tests::reset();
     }
 
     public function testFailureStatus() {
@@ -100,14 +98,12 @@ class VeritransTransactionTest extends PHPUnit_Framework_TestCase
 
       $this->assertEquals(
         VT_Tests::$lastHttpRequest["url"],
-        "https://api.veritrans.co.id/v2/Order-111/approve"
+        "https://api.sandbox.veritrans.co.id/v2/Order-111/approve"
       );
 
       $fields = VT_Tests::lastReqOptions();
       $this->assertEquals($fields["POST"], 1);
       $this->assertEquals($fields["POSTFIELDS"], null);
-
-      VT_Tests::reset();
     }
 
     public function testCancel() {
@@ -133,14 +129,15 @@ class VeritransTransactionTest extends PHPUnit_Framework_TestCase
 
       $this->assertEquals(
         VT_Tests::$lastHttpRequest["url"],
-        "https://api.veritrans.co.id/v2/Order-111/cancel"
+        "https://api.sandbox.veritrans.co.id/v2/Order-111/cancel"
       );
 
       $fields = VT_Tests::lastReqOptions();
       $this->assertEquals($fields["POST"], 1);
       $this->assertEquals($fields["POSTFIELDS"], null);
-
-      VT_Tests::reset();
     }
 
+    public function tearDown() {
+      VT_Tests::reset();
+    }
 }

--- a/tests/VeritransVtDirectTest.php
+++ b/tests/VeritransVtDirectTest.php
@@ -1,0 +1,94 @@
+<?php
+
+require_once(dirname(__FILE__) . '/VtTests.php');
+require_once(dirname(__FILE__) . '/../Veritrans.php');
+
+class VeritransVtDirectTest extends PHPUnit_Framework_TestCase
+{
+
+    public function testCharge() {
+      VT_Tests::$stubHttp = true;
+      VT_Tests::$stubHttpResponse = '{
+        "status_code": 200,
+        "redirect_url": "http://host.com/pay"
+      }';
+
+      $params = array(
+        'transaction_details' => array(
+          'order_id' => "Order-111",
+          'gross_amount' => 10000,
+        )
+      );
+
+      $charge = Veritrans_VtDirect::charge($params);
+
+      $this->assertEquals($charge->status_code, "200");
+
+      $this->assertEquals(
+        VT_Tests::$lastHttpRequest["url"],
+        "https://api.veritrans.co.id/v2/charge"
+      );
+
+      $fields = VT_Tests::lastReqOptions();
+      $this->assertEquals($fields["POST"], 1);
+      $this->assertEquals($fields["POSTFIELDS"],
+        '{"payment_type":"credit_card","transaction_details":{"order_id":"Order-111","gross_amount":10000}}'
+      );
+
+      VT_Tests::reset();
+    }
+
+    public function testRealConnect() {
+      $params = array(
+        'transaction_details' => array(
+          'order_id' => rand(),
+          'gross_amount' => 10000,
+        )
+      );
+
+      try {
+        $paymentUrl = Veritrans_VtDirect::charge($params);
+      } catch (Exception $error) {
+        $errorHappen = true;
+        $this->assertEquals(
+          $error->getMessage(),
+          "Veritrans Error (401): Access denied due to unauthorized transaction, please check client or server key");
+      }
+
+      $this->assertTrue($errorHappen);
+    }
+
+    public function testCapture() {
+      VT_Tests::$stubHttp = true;
+      VT_Tests::$stubHttpResponse = '{
+        "status_code": "200",
+        "status_message": "Success, Credit Card capture transaction is successful",
+        "transaction_id": "1ac1a089d-a587-40f1-a936-a7770667d6dd",
+        "order_id": "A27550",
+        "payment_type": "credit_card",
+        "transaction_time": "2014-08-25 10:20:54",
+        "transaction_status": "capture",
+        "fraud_status": "accept",
+        "masked_card": "481111-1114",
+        "bank": "bni",
+        "approval_code": "1408937217061",
+        "gross_amount": "55000.00"
+      }';
+
+      $capture = Veritrans_VtDirect::capture("A27550");
+
+      $this->assertEquals($capture->status_code, "200");
+
+      $this->assertEquals(
+        VT_Tests::$lastHttpRequest["url"],
+        "https://api.veritrans.co.id/v2/capture"
+      );
+
+      $fields = VT_Tests::lastReqOptions();
+      $this->assertEquals($fields["POST"], 1);
+      $this->assertEquals($fields["POSTFIELDS"], '{"transaction_id":"A27550"}');
+
+      VT_Tests::reset();
+    }
+
+}

--- a/tests/VeritransVtDirectTest.php
+++ b/tests/VeritransVtDirectTest.php
@@ -26,7 +26,7 @@ class VeritransVtDirectTest extends PHPUnit_Framework_TestCase
 
       $this->assertEquals(
         VT_Tests::$lastHttpRequest["url"],
-        "https://api.veritrans.co.id/v2/charge"
+        "https://api.sandbox.veritrans.co.id/v2/charge"
       );
 
       $fields = VT_Tests::lastReqOptions();
@@ -34,8 +34,6 @@ class VeritransVtDirectTest extends PHPUnit_Framework_TestCase
       $this->assertEquals($fields["POSTFIELDS"],
         '{"payment_type":"credit_card","transaction_details":{"order_id":"Order-111","gross_amount":10000}}'
       );
-
-      VT_Tests::reset();
     }
 
     public function testRealConnect() {
@@ -81,14 +79,15 @@ class VeritransVtDirectTest extends PHPUnit_Framework_TestCase
 
       $this->assertEquals(
         VT_Tests::$lastHttpRequest["url"],
-        "https://api.veritrans.co.id/v2/capture"
+        "https://api.sandbox.veritrans.co.id/v2/capture"
       );
 
       $fields = VT_Tests::lastReqOptions();
       $this->assertEquals($fields["POST"], 1);
       $this->assertEquals($fields["POSTFIELDS"], '{"transaction_id":"A27550"}');
-
-      VT_Tests::reset();
     }
 
+    public function tearDown() {
+      VT_Tests::reset();
+    }
 }

--- a/tests/VeritransVtWebTest.php
+++ b/tests/VeritransVtWebTest.php
@@ -9,10 +9,7 @@ class VeritransVtWebTest extends PHPUnit_Framework_TestCase
     public function testGetRedirectionUrl() {
       Veritrans_Config::$serverKey = 'My Very Secret Key';
       VT_Tests::$stubHttp = true;
-      VT_Tests::$stubHttpResponse = '{
-        "status_code": 200,
-        "redirect_url": "http://host.com/pay"
-      }';
+      VT_Tests::$stubHttpResponse = '{ "status_code": 200, "redirect_url": "http://host.com/pay" }';
 
       $params = array(
         'transaction_details' => array(
@@ -41,6 +38,47 @@ class VeritransVtWebTest extends PHPUnit_Framework_TestCase
       $this->assertEquals($fields["POSTFIELDS"],
         '{"payment_type":"vtweb","vtweb":{"credit_card_3d_secure":false},' . 
         '"transaction_details":{"order_id":"Order-111","gross_amount":10000}}'
+      );
+
+      VT_Tests::reset();
+    }
+
+    public function testGrossAmount() {
+      $params = array(
+        'transaction_details' => array(
+          'order_id' => rand()
+        ),
+        'item_details' => array( array( 'price' => 10000, 'quantity' => 5 ) )
+      );
+
+      VT_Tests::$stubHttp = true;
+      VT_Tests::$stubHttpResponse = '{ "status_code": 200, "redirect_url": "http://host.com/pay" }';
+
+      $paymentUrl = Veritrans_Vtweb::getRedirectionUrl($params);
+
+      $this->assertEquals(
+        VT_Tests::$lastHttpRequest['data_hash']['transaction_details']['gross_amount'],
+        50000
+      );
+
+      VT_Tests::reset();
+    }
+
+    public function testOverrideParams() {
+      $params = array(
+        'vtweb' => array(
+          'extra' => 'param'
+        )
+      );
+
+      VT_Tests::$stubHttp = true;
+      VT_Tests::$stubHttpResponse = '{ "status_code": 200, "redirect_url": "http://host.com/pay" }';
+
+      $paymentUrl = Veritrans_Vtweb::getRedirectionUrl($params);
+
+      $this->assertEquals(
+        VT_Tests::$lastHttpRequest['data_hash']["vtweb"],
+        array("credit_card_3d_secure" => false, "extra" => "param")
       );
 
       VT_Tests::reset();

--- a/tests/VeritransVtWebTest.php
+++ b/tests/VeritransVtWebTest.php
@@ -22,7 +22,6 @@ class VeritransVtWebTest extends PHPUnit_Framework_TestCase
 
       $this->assertEquals($paymentUrl, "http://host.com/pay");
 
-
       $this->assertEquals(
         VT_Tests::$lastHttpRequest["url"],
         "https://api.sandbox.veritrans.co.id/v2/charge"
@@ -34,6 +33,7 @@ class VeritransVtWebTest extends PHPUnit_Framework_TestCase
       );
 
       $fields = VT_Tests::lastReqOptions();
+
       $this->assertEquals($fields["POST"], 1);
       $this->assertEquals($fields["POSTFIELDS"],
         '{"payment_type":"vtweb","vtweb":{"credit_card_3d_secure":false},' . 
@@ -60,10 +60,6 @@ class VeritransVtWebTest extends PHPUnit_Framework_TestCase
       );
     }
 
-    public function tearDown() {
-      VT_Tests::reset();
-    }
-
     public function testOverrideParams() {
       $params = array(
         'vtweb' => array(
@@ -80,8 +76,6 @@ class VeritransVtWebTest extends PHPUnit_Framework_TestCase
         VT_Tests::$lastHttpRequest['data_hash']["vtweb"],
         array("credit_card_3d_secure" => false, "extra" => "param")
       );
-
-      VT_Tests::reset();
     }
 
     public function testRealConnect() {
@@ -102,6 +96,10 @@ class VeritransVtWebTest extends PHPUnit_Framework_TestCase
       }
 
       $this->assertTrue($errorHappen);
+    }
+
+    public function tearDown() {
+      VT_Tests::reset();
     }
 
 }

--- a/tests/VeritransVtWebTest.php
+++ b/tests/VeritransVtWebTest.php
@@ -25,7 +25,7 @@ class VeritransVtWebTest extends PHPUnit_Framework_TestCase
 
       $this->assertEquals(
         VT_Tests::$lastHttpRequest["url"],
-        "https://api.veritrans.co.id/v2/charge"
+        "https://api.sandbox.veritrans.co.id/v2/charge"
       );
 
       $this->assertEquals(
@@ -39,8 +39,6 @@ class VeritransVtWebTest extends PHPUnit_Framework_TestCase
         '{"payment_type":"vtweb","vtweb":{"credit_card_3d_secure":false},' . 
         '"transaction_details":{"order_id":"Order-111","gross_amount":10000}}'
       );
-
-      VT_Tests::reset();
     }
 
     public function testGrossAmount() {
@@ -60,7 +58,9 @@ class VeritransVtWebTest extends PHPUnit_Framework_TestCase
         VT_Tests::$lastHttpRequest['data_hash']['transaction_details']['gross_amount'],
         50000
       );
+    }
 
+    public function tearDown() {
       VT_Tests::reset();
     }
 

--- a/tests/VtTests.php
+++ b/tests/VtTests.php
@@ -20,7 +20,8 @@ class VT_Tests {
       CURLOPT_RETURNTRANSFER => "RETURNTRANSFER",
       CURLOPT_CAINFO => "CAINFO",
       CURLOPT_POST => "POST",
-      CURLOPT_POSTFIELDS => "POSTFIELDS"
+      CURLOPT_POSTFIELDS => "POSTFIELDS",
+      CURLOPT_PROXY => "PROXY"
     );
 
     $options = array();

--- a/tests/VtTests.php
+++ b/tests/VtTests.php
@@ -1,0 +1,35 @@
+<?php
+
+class VT_Tests {
+
+  public static $stubHttp = false;
+  public static $stubHttpResponse;
+
+  public static $lastHttpRequest;
+
+  public static function reset() {
+    VT_Tests::$stubHttp = false;
+    VT_Tests::$stubHttpResponse = null;
+    VT_Tests::$lastHttpRequest = null;
+  }
+
+  public static function lastReqOptions() {
+    $consts = array(
+      CURLOPT_URL => "URL",
+      CURLOPT_HTTPHEADER => "HTTPHEADER",
+      CURLOPT_RETURNTRANSFER => "RETURNTRANSFER",
+      CURLOPT_CAINFO => "CAINFO",
+      CURLOPT_POST => "POST",
+      CURLOPT_POSTFIELDS => "POSTFIELDS"
+    );
+
+    $options = array();
+    foreach (VT_Tests::$lastHttpRequest["curl"] as $intValue => $value) {
+      $key = $consts[$intValue] ? $consts[$intValue] : $intValue;
+      $options[$key] = $value;
+    }
+
+    return $options;
+  }
+
+}


### PR DESCRIPTION
* Create functions to stub curl request
* Add tests for vt-web
* Add tests for config
* Add tests for transaction status/cancel/approve
* Add tests for vtdirect

I was trying to stub static method but it's [not possible anymore](https://github.com/sebastianbergmann/phpunit-documentation/issues/77#issuecomment-76672507) in phpunit.

So I created functionality to stub http request (use our object instead of calling `curl_exec($ch)`), also I change it to keep all curl options in array and then set via `curl_setopt_array`.

p.s. i'm not done, still working on it