### PR TITLE
variable fix on $_SERVER['REQUEST_URI']

### DIFF
--- a/examples/vt-web/index.php
+++ b/examples/vt-web/index.php
@@ -1,5 +1,5 @@
 <?php
-  $base = $_SERVER[REQUEST_URI];
+  $base = $_SERVER['REQUEST_URI'];
 ?>
 
 <form action="<?php echo $base ?>/checkout-process.php" method="GET">


### PR DESCRIPTION
**Change log:**
- Changed ``$_SERVER[REQUEST_URI]`` to ``$_SERVER['REQUEST_URI']``

In PHP 5, this following code :
``$_SERVER[REQUEST_URI]`` found in **\examples\vt-web\index.php**
will produce this error :
``Notice: Use of undefined constant REQUEST_URI - assumed 'REQUEST_URI' ``

Explanation:
- since PHP 5, ``REQUEST_URI`` (without quotation mark) would be considered as **constant variable**, when it's not defined, above error notice would occur.
- Previously in PHP 4 and lower, ``REQUEST URI`` would be automatically converted into ``'REQUEST_URI'`` string (with quotation mark), no error notice would occur.