### PR TITLE
Add snap library & bump version

### DIFF
--- a/Veritrans.php
+++ b/Veritrans.php
@@ -21,9 +21,11 @@ require_once('Veritrans/Transaction.php');
 
 // Plumbing
 require_once('Veritrans/ApiRequestor.php');
+require_once('Veritrans/SnapApiRequestor.php');
 require_once('Veritrans/Notification.php');
 require_once('Veritrans/VtDirect.php');
 require_once('Veritrans/VtWeb.php');
+require_once('Veritrans/Snap.php');
 
 // Sanitization
 require_once('Veritrans/Sanitizer.php');

--- a/Veritrans/Config.php
+++ b/Veritrans/Config.php
@@ -39,6 +39,8 @@ class Veritrans_Config {
 
   const SANDBOX_BASE_URL = 'https://api.sandbox.veritrans.co.id/v2';
   const PRODUCTION_BASE_URL = 'https://api.veritrans.co.id/v2';
+  const SNAP_SANDBOX_BASE_URL = 'https://vtcheckout.sandbox.veritrans.co.id/v1';
+  const SNAP_PRODUCTION_BASE_URL = 'https://vtcheckout.veritrans.co.id/v1';
 
   /**
    * @return string Veritrans API URL, depends on $isProduction
@@ -47,5 +49,14 @@ class Veritrans_Config {
   {
     return Veritrans_Config::$isProduction ?
         Veritrans_Config::PRODUCTION_BASE_URL : Veritrans_Config::SANDBOX_BASE_URL;
+  }
+
+  /**
+   * @return string Snap API URL, depends on $isProduction
+   */
+  public static function getSnapBaseUrl()
+  {
+    return Veritrans_Config::$isProduction ?
+        Veritrans_Config::SNAP_PRODUCTION_BASE_URL : Veritrans_Config::SNAP_SANDBOX_BASE_URL;
   }
 }

--- a/Veritrans/Snap.php
+++ b/Veritrans/Snap.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Create Snap payment page and return snap token
+ *
+ */
+class Veritrans_Snap {
+
+  /**
+   * Create Snap payment page
+   *
+   * Example:
+   *
+   * ```php
+   *   $params = array(
+   *     'transaction_details' => array(
+   *       'order_id' => rand(),
+   *       'gross_amount' => 10000,
+   *     )
+   *   );
+   *   $paymentUrl = Veritrans_Snap::getSnapToken($params);
+   * ```
+   *
+   * @param array $params Payment options
+   * @return string Snap token.
+   * @throws Exception curl error or veritrans error
+   */
+  public static function getSnapToken($params)
+  {
+    $payloads = array(
+      'credit_card' => array(
+        // 'enabled_payments' => array('credit_card'),
+        'secure' => Veritrans_Config::$is3ds
+      )
+    );
+
+    if (array_key_exists('item_details', $params)) {
+      $gross_amount = 0;
+      foreach ($params['item_details'] as $item) {
+        $gross_amount += $item['quantity'] * $item['price'];
+      }
+      $params['transaction_details']['gross_amount'] = $gross_amount;
+    }
+
+    if (Veritrans_Config::$isSanitized) {
+      Veritrans_Sanitizer::jsonRequest($params);
+    }
+
+    $params = array_replace_recursive($payloads, $params);
+
+    $result = Veritrans_SnapApiRequestor::post(
+        Veritrans_Config::getSnapBaseUrl() . '/charge',
+        Veritrans_Config::$serverKey,
+        $params);
+
+    return $result->token_id;
+  }
+}

--- a/Veritrans/SnapApiRequestor.php
+++ b/Veritrans/SnapApiRequestor.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Send request to Snap API
+ * Better don't use this class directly, use Veritrans_Snap
+ */
+
+class Veritrans_SnapApiRequestor {
+
+  /**
+   * Send GET request
+   * @param string  $url
+   * @param string  $server_key
+   * @param mixed[] $data_hash
+   */
+  public static function get($url, $server_key, $data_hash)
+  {
+    return self::remoteCall($url, $server_key, $data_hash, false);
+  }
+
+  /**
+   * Send POST request
+   * @param string  $url
+   * @param string  $server_key
+   * @param mixed[] $data_hash
+   */
+  public static function post($url, $server_key, $data_hash)
+  {
+    return self::remoteCall($url, $server_key, $data_hash, true);
+  }
+
+  /**
+   * Actually send request to API server
+   * @param string  $url
+   * @param string  $server_key
+   * @param mixed[] $data_hash
+   * @param bool    $post
+   */
+  public static function remoteCall($url, $server_key, $data_hash, $post = true)
+  {
+    $ch = curl_init();
+
+    $curl_options = array(
+      CURLOPT_URL => $url,
+      CURLOPT_HTTPHEADER => array(
+        'Content-Type: application/json',
+        'Accept: application/json',
+        'Authorization: Basic ' . base64_encode($server_key . ':')
+      ),
+      CURLOPT_RETURNTRANSFER => 1,
+      CURLOPT_CAINFO => dirname(__FILE__) . "/../data/cacert.pem"
+    );
+
+    // merging with Veritrans_Config::$curlOptions
+    if (count(Veritrans_Config::$curlOptions)) {
+      // We need to combine headers manually, because it's array and it will no be merged
+      if (Veritrans_Config::$curlOptions[CURLOPT_HTTPHEADER]) {
+        $mergedHeders = array_merge($curl_options[CURLOPT_HTTPHEADER], Veritrans_Config::$curlOptions[CURLOPT_HTTPHEADER]);
+        $headerOptions = array( CURLOPT_HTTPHEADER => $mergedHeders );
+      } else {
+        $mergedHeders = array();
+      }
+
+      $curl_options = array_replace_recursive($curl_options, Veritrans_Config::$curlOptions, $headerOptions);
+    }
+
+    if ($post) {
+      $curl_options[CURLOPT_POST] = 1;
+
+      if ($data_hash) {
+        $body = json_encode($data_hash);
+        $curl_options[CURLOPT_POSTFIELDS] = $body;
+      } else {
+        $curl_options[CURLOPT_POSTFIELDS] = '';
+      }
+    }
+
+    curl_setopt_array($ch, $curl_options);
+
+    // For testing purpose
+    if (class_exists('VT_Tests') && VT_Tests::$stubHttp) {
+      $result = self::processStubed($curl_options, $url, $server_key, $data_hash, $post);
+      $info = VT_Tests::$stubHttpStatus;
+    } else {
+      $result = curl_exec($ch);
+      $info = curl_getinfo($ch);
+      // curl_close($ch);
+    }
+
+
+    if ($result === FALSE) {
+      throw new Exception('CURL Error: ' . curl_error($ch), curl_errno($ch));
+    }
+    else {
+      $result_array = json_decode($result);
+      if ($info['http_code'] != 200) {
+        $message = 'Veritrans Error (' . $info['http_code'] . '): '
+            . implode(',', $result_array->error_messages);
+        throw new Exception($message, $info['http_code']);
+
+      }
+      else {
+        return $result_array;
+      }
+    }
+  }
+
+  private static function processStubed($curl, $url, $server_key, $data_hash, $post) {
+    VT_Tests::$lastHttpRequest = array(
+      "url" => $url,
+      "server_key" => $server_key,
+      "data_hash" => $data_hash,
+      "post" => $post,
+      "curl" => $curl
+    );
+
+    return VT_Tests::$stubHttpResponse;
+  }
+}

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "veritrans/veritrans-php",
     "description": "PHP Wraper for Veritrans VT-Web Payment API.",
     "homepage": "https://veritrans.co.id",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "type": "library",
     "license":"GPL-3.0",
     "authors": [

--- a/examples/snap/checkout-process.php
+++ b/examples/snap/checkout-process.php
@@ -2,7 +2,7 @@
 require_once(dirname(__FILE__) . '/../../Veritrans.php');
 
 //Set Your server key
-Veritrans_Config::$serverKey = "VT-server-UJ4uPuXhwiNXwhpQx5-S76U1";
+Veritrans_Config::$serverKey = "<Set your ServerKey here>";
 
 // Uncomment for production environment
 // Veritrans_Config::$isProduction = true;

--- a/examples/snap/checkout-process.php
+++ b/examples/snap/checkout-process.php
@@ -1,0 +1,123 @@
+<?php
+require_once(dirname(__FILE__) . '/../../Veritrans.php');
+
+//Set Your server key
+Veritrans_Config::$serverKey = "VT-server-UJ4uPuXhwiNXwhpQx5-S76U1";
+
+// Uncomment for production environment
+// Veritrans_Config::$isProduction = true;
+
+// Uncomment to enable sanitization
+// Veritrans_Config::$isSanitized = true;
+
+// Uncomment to enable 3D-Secure
+// Veritrans_Config::$is3ds = true;
+
+// Required
+$transaction_details = array(
+  'order_id' => rand(),
+  'gross_amount' => 94000, // no decimal allowed for creditcard
+);
+
+// Optional
+$item1_details = array(
+  'id' => 'a1',
+  'price' => 18000,
+  'quantity' => 3,
+  'name' => "Apple"
+);
+
+// Optional
+$item2_details = array(
+  'id' => 'a2',
+  'price' => 20000,
+  'quantity' => 2,
+  'name' => "Orange"
+);
+
+// Optional
+$item_details = array ($item1_details, $item2_details);
+
+// Optional
+$billing_address = array(
+  'first_name'    => "Andri",
+  'last_name'     => "Litani",
+  'address'       => "Mangga 20",
+  'city'          => "Jakarta",
+  'postal_code'   => "16602",
+  'phone'         => "081122334455",
+  'country_code'  => 'IDN'
+);
+
+// Optional
+$shipping_address = array(
+  'first_name'    => "Obet",
+  'last_name'     => "Supriadi",
+  'address'       => "Manggis 90",
+  'city'          => "Jakarta",
+  'postal_code'   => "16601",
+  'phone'         => "08113366345",
+  'country_code'  => 'IDN'
+);
+
+// Optional
+$customer_details = array(
+  'first_name'    => "Andri",
+  'last_name'     => "Litani",
+  'email'         => "andri@litani.com",
+  'phone'         => "081122334455",
+  'billing_address'  => $billing_address,
+  'shipping_address' => $shipping_address
+);
+
+$enable_payments = array('credit_card','cimb_clicks','mandiri_clickpay','echannel');
+
+// Fill transaction details
+$transaction = array(
+  'enabled_payments' => $enable_payments,
+  'transaction_details' => $transaction_details,
+  'customer_details' => $customer_details,
+  'item_details' => $item_details,
+);
+
+$response = Veritrans_Snap::getSnapToken($transaction);
+error_log($response);
+echo $response;
+?>
+
+<!DOCTYPE html>
+<html>
+  <head>
+      <meta charset="utf-8">
+      <!-- Cross compatibility -->
+      <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+      <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+      <title>Toko Buah</title>
+      <meta name="description" content=""/>
+  </head>
+  <body>
+
+    <button id="pay-button">Pay!</button>
+
+    <div id="result-type"></div>
+    <div id="result-data"></div>
+    <script src="https://vtcheckout.sandbox.veritrans.co.id/snap.js"></script>
+    <script type="text/javascript">
+      var payButton = document.getElementById('pay-button');
+      var resultType = document.getElementById('result-type');
+      var resultData = document.getElementById('result-data');
+      function changeResult(type,data){
+        resultType.innerHTML = type;
+        resultData.innerHTML = JSON.stringify(data);
+      }
+      payButton.onclick = function(){
+        snap.pay('<?=$response?>', {
+          env: 'sandbox',
+          onSuccess: function(result){changeResult('success', result)},
+          onPending: function(result){changeResult('pending', result)},
+          onError: function(result){changeResult('error', result)}
+        });
+      };
+    </script>
+  </body>
+</html>

--- a/examples/snap/index.php
+++ b/examples/snap/index.php
@@ -1,0 +1,16 @@
+<?php
+  $base = $_SERVER['REQUEST_URI'];
+?>
+
+<h3>Selected Items:</h3>
+<ul>
+  <li>Jeruk 2 kg x @20000</li>
+  <li>Apel 3 kg x @18000</li>
+</ul>
+
+<h4>Total: Rp 94.000,00</h4>
+
+<form action="<?php echo $base ?>checkout-process.php" method="POST">
+  <input type="hidden" name="amount" value="94000"/>
+  <input type="submit" value="Confirm">
+</form>

--- a/tests/VeritransSnapApiRequestorTest.php
+++ b/tests/VeritransSnapApiRequestorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+class VeritransSnapApiRequestorTest extends PHPUnit_Framework_TestCase
+{
+
+    public function testConfigOptionsOverrideCurlOptions() {
+      VT_Tests::$stubHttp = true;
+      VT_Tests::$stubHttpResponse = '{ "status_code": "200" }';
+      VT_Tests::$stubHttpStatus = array('http_code' => 200);
+
+      Veritrans_Config::$curlOptions = array(
+        CURLOPT_HTTPHEADER => array( "User-Agent: testing lib" ),
+        CURLOPT_PROXY => "http://proxy.com"
+      );
+
+      $resp = Veritrans_SnapApiRequestor::post("http://example.com", "", "");
+
+      $fields = VT_Tests::lastReqOptions();
+      $this->assertTrue(in_array("User-Agent: testing lib", $fields["HTTPHEADER"]));
+      $this->assertTrue(in_array('Content-Type: application/json', $fields["HTTPHEADER"]));
+
+      $this->assertEquals($fields["PROXY"], "http://proxy.com");
+    }
+
+    public function tearDown() {
+      VT_Tests::reset();
+      Veritrans_Config::$curlOptions = array();
+    }
+
+}

--- a/tests/VeritransSnapTest.php
+++ b/tests/VeritransSnapTest.php
@@ -1,0 +1,105 @@
+<?php
+
+class VeritransSnapTest extends PHPUnit_Framework_TestCase
+{
+
+    public function testGetSnapToken() {
+      Veritrans_Config::$serverKey = 'My Very Secret Key';
+      VT_Tests::$stubHttp = true;
+      VT_Tests::$stubHttpResponse = '{ "token_id": "abcdefghijklmnopqrstuvwxyz" }';
+      VT_Tests::$stubHttpStatus = array('http_code' => 200);
+
+      $params = array(
+        'transaction_details' => array(
+          'order_id' => "Order-111",
+          'gross_amount' => 10000,
+        )
+      );
+
+      $tokenId = Veritrans_Snap::getSnapToken($params);
+
+      $this->assertEquals($tokenId, "abcdefghijklmnopqrstuvwxyz");
+
+      $this->assertEquals(
+        VT_Tests::$lastHttpRequest["url"],
+        "https://vtcheckout.sandbox.veritrans.co.id/v1/charge"
+      );
+
+      $this->assertEquals(
+        VT_Tests::$lastHttpRequest["server_key"],
+        'My Very Secret Key'
+      );
+
+      $fields = VT_Tests::lastReqOptions();
+
+      $this->assertEquals($fields["POST"], 1);
+      $this->assertEquals($fields["POSTFIELDS"],
+        '{"credit_card":{"secure":false},' .
+        '"transaction_details":{"order_id":"Order-111","gross_amount":10000}}'
+      );
+    }
+
+    public function testGrossAmount() {
+      $params = array(
+        'transaction_details' => array(
+          'order_id' => rand()
+        ),
+        'item_details' => array( array( 'price' => 10000, 'quantity' => 5 ) )
+      );
+
+      VT_Tests::$stubHttp = true;
+      VT_Tests::$stubHttpResponse = '{ "token_id": "abcdefghijklmnopqrstuvwxyz" }';
+      VT_Tests::$stubHttpStatus = array('http_code' => 200);
+
+      $tokenId = Veritrans_Snap::getSnapToken($params);
+
+      $this->assertEquals(
+        VT_Tests::$lastHttpRequest['data_hash']['transaction_details']['gross_amount'],
+        50000
+      );
+    }
+
+    public function testOverrideParams() {
+      $params = array(
+        'echannel' => array(
+          'bill_info1' => 'bill_value1'
+        )
+      );
+
+      VT_Tests::$stubHttp = true;
+      VT_Tests::$stubHttpResponse = '{ "token_id": "abcdefghijklmnopqrstuvwxyz" }';
+      VT_Tests::$stubHttpStatus = array('http_code' => 200);
+
+      $tokenId = Veritrans_Snap::getSnapToken($params);
+
+      $this->assertEquals(
+        VT_Tests::$lastHttpRequest['data_hash']['echannel'],
+        array('bill_info1' => 'bill_value1')
+      );
+    }
+
+    public function testRealConnect() {
+      $params = array(
+        'transaction_details' => array(
+          'order_id' => rand(),
+          'gross_amount' => 10000,
+        )
+      );
+
+      try {
+        $tokenId = Veritrans_Snap::getSnapToken($params);
+      } catch (Exception $error) {
+        $errorHappen = true;
+        $this->assertEquals(
+          $error->getMessage(),
+          "Veritrans Error (401): Access denied due to unauthorized transaction, please check client or server key");
+      }
+
+      $this->assertTrue($errorHappen);
+    }
+
+    public function tearDown() {
+      VT_Tests::reset();
+    }
+
+}

--- a/tests/VtTests.php
+++ b/tests/VtTests.php
@@ -4,6 +4,7 @@ class VT_Tests {
 
   public static $stubHttp = false;
   public static $stubHttpResponse;
+  public static $stubHttpStatus;
 
   public static $lastHttpRequest;
 

--- a/tests/integration/VtTransactionIntegrationTest.php
+++ b/tests/integration/VtTransactionIntegrationTest.php
@@ -17,7 +17,7 @@ class VtTransactionIntegrationTest extends VtIntegrationTest {
 		$this->assertEquals($status_response->gross_amount, $charge_params['transaction_details']['gross_amount']);
 		$this->assertEquals($status_response->transaction_id, $charge_response->transaction_id);
 		$this->assertEquals($status_response->transaction_time, $charge_response->transaction_time);
-		$this->assertEquals($status_response->status_message, 'Success, transaction found');
+		$this->assertEquals($status_response->status_message, 'Success, transaction is found');
 
 		$this->assertTrue(isset($status_response->signature_key));
 	}


### PR DESCRIPTION
Add snap veritrans library
- Module usage: `Veritrans_Snap.getSnapToken($params)`

Why we have different endpoint? 
- Snap service != payment api service
- Current domain is temporary
- When domain is ready, will be changed to **app.veritrans.co.id/snap**

Why we have different api requestor?
- Different rule to raise error
- Previously, error is raised when JSON response has `status_code` != 200, 201, 202, 407
- Now, error is raised when HTTP status != 200 (notice JSON response now don't have `status_code` attribute)

Previous implementation (VT-Direct & VT-Web) are leaved as it is :rainbow: 

For sandbox testing, you may use any sandbox server key. Please refer to `/examples/snap/checkout-process.php`. Production environment is **not** available for now.

---

I also bumped composer version to `1.1.0` if accepted :white_check_mark: 

Collaborator: @harrypujianto @rizdaprasetya