### PR TITLE
add validation message if error too general example error 400

### DIFF
--- a/Veritrans/ApiRequestor.php
+++ b/Veritrans/ApiRequestor.php
@@ -93,6 +93,7 @@ class Veritrans_ApiRequestor {
       if (!in_array($result_array->status_code, array(200, 201, 202, 407))) {
         $message = 'Veritrans Error (' . $result_array->status_code . '): '
             . $result_array->status_message;
+        if (isset($result_array->validation_messages)) $message .= '. Validation Messages (' . implode(", ", $result_array->validation_messages) . ')';
         throw new Exception($message, $result_array->status_code);
       }
       else {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "veritrans/veritrans-php",
+    "name": "arthurnumen/veritrans-php",
     "description": "PHP Wraper for Veritrans VT-Web Payment API.",
     "homepage": "https://veritrans.co.id",
     "version": "1.0.1",


### PR DESCRIPTION
display validation message, example bank can't use "-" or empty, so we can trace quickly the error from veritrans
