### PR TITLE
Remove unused "env" option in Snap example code

### DIFF
--- a/examples/snap/checkout-process.php
+++ b/examples/snap/checkout-process.php
@@ -109,7 +109,6 @@ echo $snapToken;
       }
       payButton.onclick = function(){
         snap.pay('<?=$snapToken?>', {
-          env: 'sandbox',
           onSuccess: function(result){changeResult('success', result)},
           onPending: function(result){changeResult('pending', result)},
           onError: function(result){changeResult('error', result)}

--- a/tests/VeritransSnapTest.php
+++ b/tests/VeritransSnapTest.php
@@ -92,7 +92,7 @@ class VeritransSnapTest extends PHPUnit_Framework_TestCase
         $errorHappen = true;
         $this->assertEquals(
           $error->getMessage(),
-          "Veritrans Error (401): Access denied due to unauthorized transaction, please check client or server key");
+          "Veritrans Error (401): Access denied due to unauthorized transaction, please check client or server key,Visit https://snap-docs.midtrans.com/#request-headers for more details");
       }
 
       $this->assertTrue($errorHappen);


### PR DESCRIPTION
```
env: 'sandbox',
```
above part of code would result in error, because snap.js no longer recognize this `env` options