### PR TITLE
Allow Snap API usage with redirection

### DIFF
--- a/Veritrans/Snap.php
+++ b/Veritrans/Snap.php
@@ -24,7 +24,30 @@ class Veritrans_Snap {
    * @return string Snap token.
    * @throws Exception curl error or veritrans error
    */
-  public static function getSnapToken($params)
+  public static function getSnapToken($params) {
+    return (Veritrans_Snap::createTransaction($params))->token;
+  }
+
+  /**
+   * Create Snap payment page, with this version returning full API response
+   *
+   * Example:
+   *
+   * ```php
+   *   $params = array(
+   *     'transaction_details' => array(
+   *       'order_id' => rand(),
+   *       'gross_amount' => 10000,
+   *     )
+   *   );
+   *   $paymentUrl = Veritrans_Snap::getSnapToken($params);
+   * ```
+   *
+   * @param array $params Payment options
+   * @return object Snap response (token and redirect_url).
+   * @throws Exception curl error or veritrans error
+   */
+  public static function createTransaction($params)
   {
     $payloads = array(
       'credit_card' => array(
@@ -52,6 +75,6 @@ class Veritrans_Snap {
         Veritrans_Config::$serverKey,
         $params);
 
-    return $result->token;
-  }
+    return $result;
+  }  
 }


### PR DESCRIPTION
In the latest API doc, Snap create transaction returns not only `token` but `redirect_url` if one wants to have a dedicated page for payment instead of JS pop-up (I do want, because I want to allow guest to put in promo code just before payment).

I can patch it in my project, but would be much better if the official version supports it, so that composer will not overwrite my patch. My proposed pull request is a quick way to return the full response while maintaining backward compatibility, but feel free to adjust the function name / design.