### PR TITLE
Remove internal `cacert.pem` usage - to prevent future API's SSL cert unrecognized issue

### DIFF
--- a/Veritrans/ApiRequestor.php
+++ b/Veritrans/ApiRequestor.php
@@ -47,7 +47,7 @@ class Veritrans_ApiRequestor {
         'Authorization: Basic ' . base64_encode($server_key . ':')
       ),
       CURLOPT_RETURNTRANSFER => 1,
-      CURLOPT_CAINFO => dirname(__FILE__) . "/../data/cacert.pem"
+      // CURLOPT_CAINFO => dirname(__FILE__) . "/../data/cacert.pem"
     );
 
     // merging with Veritrans_Config::$curlOptions

--- a/Veritrans/SnapApiRequestor.php
+++ b/Veritrans/SnapApiRequestor.php
@@ -47,7 +47,7 @@ class Veritrans_SnapApiRequestor {
         'Authorization: Basic ' . base64_encode($server_key . ':')
       ),
       CURLOPT_RETURNTRANSFER => 1,
-      CURLOPT_CAINFO => dirname(__FILE__) . "/../data/cacert.pem"
+      // CURLOPT_CAINFO => dirname(__FILE__) . "/../data/cacert.pem"
     );
 
     // merging with Veritrans_Config::$curlOptions

--- a/data/cacert.pem
+++ b/data/cacert.pem
@@ -1,3 +1,5 @@
+## WARN: THIS FILE IS NOT USED by default by Veritrans PHP Library!
+## See: https://github.com/veritrans/veritrans-php/pull/94 for info.
 ##
 ## Bundle of CA Root Certificates
 ##


### PR DESCRIPTION
Using internal bundle of `cacert.pem` is not flexible enough. 
**Issue**: Incase API's SSL cert is updated using new cert issuer that is not defined on the `cacert.pem` (CA bundle), PHP Curl will refuse to connect. Which require constant updating of `cacert.pem` (CA bundle)
**Fix:** internal `cacert.pem` (CA bundle) usage is removed, so it will use OS/CURL level CA Cert bundle, which hopefully more frequently updated.
This change is soft delete (commented out), incase specific merchant need to use internal CA cert in specific case.